### PR TITLE
[EXP-4778] Fix checkOverflowVisible left calculation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,8 @@ var checkOverflowVisible = function checkOverflowVisible(component, parent) {
   var _parent$getBoundingCl = parent.getBoundingClientRect(),
       parentTop = _parent$getBoundingCl.top,
       parentHeight = _parent$getBoundingCl.height,
-      parentWidth = _parent$getBoundingCl.width;
+      parentWidth = _parent$getBoundingCl.width,
+      parentLeft = _parent$getBoundingCl.left;
 
   var windowInnerHeight = window.innerHeight || document.documentElement.clientHeight,
       xAxisLazyLoad = parent.classList.contains('lazyload-x-axis'),
@@ -87,7 +88,7 @@ var checkOverflowVisible = function checkOverflowVisible(component, parent) {
   var _node$getBoundingClie = node.getBoundingClientRect(),
       top = _node$getBoundingClie.top,
       height = _node$getBoundingClie.height,
-      left = _node$getBoundingClie.left;
+      left = _node$getBoundingClie.left - parentLeft; // [EXP-4778] left should be calculated over parent position
 
   var offsetTop = top - intersectionTop; // element's top relative to intersection
 

--- a/lib/utils/scrollParent.js
+++ b/lib/utils/scrollParent.js
@@ -23,6 +23,11 @@ exports.default = function (node) {
     }
 
     var style = window.getComputedStyle(parent);
+
+    if (!style) {
+      return node.ownerDocument || document;
+    }
+
     var position = style.position;
     var overflow = style.overflow;
     var overflowX = style['overflow-x'];


### PR DESCRIPTION
## Solution
Fixed `checkOverflowVisible` function left calculation. It was done over the viewport instead of over the parent.

## Bonus
Prevent Firefox crash on getComputedStyle call.
Rollbar item: https://rollbar.com/wuakitv/kraken/items/1180/?person_page=0&#traceback
Related info: https://stackoverflow.com/questions/46127213/how-to-fix-typeerror-window-getcomputedstyle-is-null-in-firefox